### PR TITLE
Rename variables for clarity in SafeVerifyOutcome and checkTargets function

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -94,7 +94,7 @@ def processFileDeclarations
         -- IO.println s!":= {ci.value!}"
       let (_, s) := (CollectAxioms.collect n).run env |>.run {}
       -- IO.println s.axioms
-      out := out.insert n ⟨n, ci, s.axioms⟩ -- why store the name twice?
+      out := out.insert n ⟨n, ci, s.axioms⟩
   return out
 
 /-- The failure modes that can occur when running the safeverify check on a single declaration. -/


### PR DESCRIPTION
This PR renames the variables in `checkTargets` and fields of `SafeVerifyOutcome` to make more sense.

The optional value within `SafeVerifyOutcome` should be the submission ConstantInfo, rather than the target ConstantInfo. Because we are checking each declaration in the target, we only ever create a `SafeVerifyOutcome` for a specific extant declaration in the target file. What is in doubt is that there will be a corresponding decl in the submission file, because a malicious submitter could simply leave the declaration out.

Indeed, this is how `checkTargets` constructs this, but because the variables are not named to indicate which they come from, the fact that the target info was being passed as the "submissionConstant" was obscured.

I have also changed the order in which the arguments to `checkTargets` are passed, I think it is easier to follow if, like the fields of `SafeVerifyOutcome` and the arguments to the Cli, the target comes first