### PR TITLE
fix: avoid unnecessary error throwing

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -121,6 +121,7 @@ submission file containing proofs). -/
 def runSafeVerify (targetFile submissionFile : System.FilePath)
     (disallowPartial : Bool) (verbose : Bool := false) :
     IO <| (HashMap Name SafeVerifyOutcome) × Bool := do
+  let mut hasFailures := false
   IO.eprintln "------------------"
   let targetInfo ← replayFile targetFile disallowPartial
   IO.eprintln "------------------"
@@ -128,9 +129,9 @@ def runSafeVerify (targetFile submissionFile : System.FilePath)
   for (n, info) in submissionInfo do
     if !checkAxioms info then
       IO.eprintln s!"{n} used disallowed axioms. {info.axioms}"
+      hasFailures := true
   let checkOutcome := checkTargets targetInfo submissionInfo
   IO.eprintln "------------------"
-  let mut hasFailures := false
   for (name, outcome) in checkOutcome do
     if let some failure := outcome.failureMode then
       hasFailures := true
@@ -151,12 +152,6 @@ def runSafeVerify (targetFile submissionFile : System.FilePath)
             IO.eprintln s!"  Disallowed axioms used: {submissionInfo.axioms.filter (· ∉ AllowedAxioms)}"
         | _ => pure ()
   IO.eprintln "------------------"
-  if hasFailures then
-    IO.eprintln "SafeVerify check failed."
-    if !verbose then
-      IO.eprintln s!"For more diagnostic information about failures, run safe_verify with the -v (or --verbose) flag."
-  else
-    IO.eprintln "SafeVerify check passed."
   return (checkOutcome, hasFailures)
 
 open Cli
@@ -189,7 +184,7 @@ def runMain (p : Parsed) : IO UInt32 := do
   if hasFailures then
     let nonVerboseMsg :=
       "For more diagnostic information about failures, run safe_verify with the -v (or --verbose) flag."
-    IO s!"SafeVerify check failed.{if !verbose then nonVerboseMsg else ""}"
+    throw <| IO.userError s!"SafeVerify check failed.{if !verbose then nonVerboseMsg else ""}"
   else
     IO.eprintln "SafeVerify check passed."
   return 0

--- a/Main.lean
+++ b/Main.lean
@@ -178,12 +178,12 @@ def runMain (p : Parsed) : IO UInt32 := do
   IO.eprintln s!"Running SafeVerify on target file: {targetFile} and submission file: {submissionFile}."
   let (output, hasFailures) ← runSafeVerify targetFile submissionFile disallowPartial verbose
   let jsonOutput := ToJson.toJson output.toArray
-  let some jsonPathFlag := p.flag? "save" | return 0
-  let jsonPath := jsonPathFlag.as! System.FilePath
-  IO.FS.writeFile jsonPath (ToString.toString jsonOutput)
+  if let some jsonPathFlag := p.flag? "save" then
+    let jsonPath := jsonPathFlag.as! System.FilePath
+    IO.FS.writeFile jsonPath (ToString.toString jsonOutput)
   if hasFailures then
     let nonVerboseMsg :=
-      "For more diagnostic information about failures, run safe_verify with the -v (or --verbose) flag."
+      " For more diagnostic information about failures, run safe_verify with the -v (or --verbose) flag."
     throw <| IO.userError s!"SafeVerify check failed.{if !verbose then nonVerboseMsg else ""}"
   else
     IO.eprintln "SafeVerify check passed."


### PR DESCRIPTION
This PR changes the behaviour of the safe_verify binary to avoid throwing an error if the check was run successfully but the solution file didn't pass the check. The proposal is the following: we should keep error throwing for cases where the user input is ill-formed, and communicate failure in passing the check in some other way (e.g. in the output that is printed). This ensures that a Json output file can always be created (currently this is only created when the check succeeds, which does make it a little less useful!). 

As a drive-by, the logging is now done using `IO.eprintln` rather than `IO.println`.