### PR TITLE
Security: Level rebuild, struct Nat validation, target Init check

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -194,9 +194,11 @@ def readImports (filePath : System.FilePath) : IO (Array Import) := do
 
 /-- Check that submission imports are a superset of target imports.
 This prevents attacks where submissions omit imports to redefine types. -/
-def checkImportSuperset (submissionFile : System.FilePath)
+def checkImportSuperset (targetFile submissionFile : System.FilePath)
     (targetImports submissionImports : Array Import) : IO Unit := do
-  -- Reject empty imports (prelude attack)
+  -- Both target and submission must import Init
+  unless targetImports.any (·.module == `Init) do
+    throw <| IO.userError s!"Target '{targetFile}' does not import Init. Refusing to verify against a prelude-based target."
   if submissionImports.isEmpty then
     throw <| IO.userError s!"'{submissionFile}' has no imports (possible prelude file). Submissions must import Init to prevent kernel type redefinition."
   -- Check that every target import appears in submission imports
@@ -243,7 +245,7 @@ def runSafeVerify (targetFile submissionFile : System.FilePath)
   -- Import superset check: submission must import everything the target does
   let targetImports ← readImports targetFile
   let submissionImports ← readImports submissionFile
-  checkImportSuperset submissionFile targetImports submissionImports
+  checkImportSuperset targetFile submissionFile targetImports submissionImports
   IO.println "------------------"
   let targetInfo ← replayFile targetFile disallowPartial
   IO.println "------------------"


### PR DESCRIPTION
Follow-up to #19. Additional security hardening:

### Changes
1. **Rebuild Level objects** (5cafc55) — Deep-copy all `Level` nodes in `.sort` and `.const` expressions before kernel replay. Catches `unsafeCast` on `Level` objects (e.g. the `magic`/`isProp` universe-polymorphism attack).

2. **Extend Nat literal validation to inductives/constructors/recursors** (29ef514) — Scan `inductInfo`, `ctorInfo`, and `recInfo` types for corrupted Nat literals, not just defs/theorems/opaques.

3. **Require target to import Init** (867fcd9) — Defense-in-depth: refuse to verify against a prelude-based target file.

### Test results (12 cases, all pass)
- Prelude attack → rejected
- Missing import → rejected  
- unsafeCast Nat (bare) → rejected
- unsafeCast Nat (nested in Prod) → rejected
- Level unsafeCast attack → rejected
- Benign helper def → pass
- Helper lemma → pass
- Large valid Nat → pass
- Structure with Nats → pass
- Wrong theorem type → rejected (sorryAx)
- Missing declaration → rejected
- Matching def+theorem → pass